### PR TITLE
Add 'six' as a requirement to requirements.txt and setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyyaml
 pytest
 coverage
 pytest-cov
+six

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'antlr4-python3-runtime>=4.6',
         'click',
         'watchdog',
+        'six',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
It seems like the 'six' package is a dependency and needs to be installed
expliclty.