### PR TITLE
Fix generator.py to always write with the utf-8 encoding

### DIFF
--- a/qface/generator.py
+++ b/qface/generator.py
@@ -85,7 +85,7 @@ class Generator(object):
                 click.secho('preserve changed file: {0}'.format(path), fg='blue')
             else:
                 click.secho('write changed file: {0}'.format(path), fg='blue')
-                path.open('w').write(data)
+                path.open('w', encoding='utf-8').write(data)
 
     def _has_different_content(self, data, path):
         if not path.exists():


### PR DESCRIPTION
On windows the default encoding is not utf-8, that's why need to
set it when opening a file for writing