### PR TITLE
antlr4 has a implicit dependency towards the 'typing' module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 antlr4-python3-runtime>=4.6
+typing
 jinja2
 click
 path.py

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'path.py',
         'pyyaml',
         'antlr4-python3-runtime>=4.6',
+        'typing',
         'click',
         'watchdog',
         'six',


### PR DESCRIPTION
antlr doesn't specify the dependency anywhere and on most systems
'typing' is already installed, but on systems like RHEL it is not
installed and needs to be specified explicitly