### PR TITLE
Fix module name capitalisation

### DIFF
--- a/qface/idl/domain.py
+++ b/qface/idl/domain.py
@@ -335,7 +335,8 @@ class Module(Symbol):
     @property
     def module_name(self):
         """ returns a capitalized name from the module name """
-        return self.name.split('.')[-1].capitalize()
+        str = module.name.split('.')[-1]
+        return str[:1].upper() + str[1:]
 
     def lookup(self, name: str, fragment: str = None):
         '''lookup a symbol by name. If symbol is not local


### PR DESCRIPTION
Change module name capitalization so that only the first letter is
affected. Without this, ‘module QtIviVehicleFunctions’ gets capitalised
as Qtivivehiclefunctions which looks awful.

This can’t easily be worked around in the generator as all the symbol
name lookup for type names is based on this.