### PR TITLE
Fixes FileNotFoundError about the empty string path

### DIFF
--- a/qface/generator.py
+++ b/qface/generator.py
@@ -196,7 +196,8 @@ class Generator(object):
     def _write(self, file_path: Path, template: str, context: dict, preserve: bool = False, force: bool = False):
         force = self.force or force
         path = self.resolved_path / Path(self.apply(file_path, context))
-        path.parent.makedirs_p()
+        if path.parent:
+            path.parent.makedirs_p()
         logger.info('write {0}'.format(path))
         data = self.render(template, context)
         if self._has_different_content(data, path) or force:


### PR DESCRIPTION
An error occurred when I tried the custom generator sample documented in https://qface.readthedocs.io/en/latest/index.html#custom-generator

```
FileNotFoundError: [Errno 2] No such file or directory: Path('')
```