### PR TITLE
Improve error handling when parsing annotation files

### DIFF
--- a/qface/generator.py
+++ b/qface/generator.py
@@ -344,7 +344,11 @@ class FileSystem(object):
         if not Path(document).exists():
             return
         meta = FileSystem.load_yaml(document)
-        click.secho('merge: {0}'.format(document.name), fg='blue')
+        if not meta:
+            click.secho('skipping empty: {0}'.format(document.name), fg='blue')
+            return
+        else:
+            click.secho('merge: {0}'.format(document.name), fg='blue')
         try:
             for identifier, data in meta.items():
                 symbol = system.lookup(identifier)

--- a/qface/idl/domain.py
+++ b/qface/idl/domain.py
@@ -55,10 +55,10 @@ class System(object):
             return self._moduleMap[name]
         # <module>.<Symbol>
         (module_name, type_name, fragment_name) = self.split_typename(name)
-        if not module_name and type_name:
-            click.secho('not able to lookup symbol: {0}'.format(name), fg='red')
-            return None
+        if not module_name in self._moduleMap:
+            raise Exception('not able to lookup symbol: {0}'.format(name))
         module = self._moduleMap[module_name]
+        # The module lookup calls this function again if the type_name doesn't exist
         return module.lookup(type_name, fragment_name)
 
     @staticmethod

--- a/tests/in/broken_tuner_annotations.yaml
+++ b/tests/in/broken_tuner_annotations.yaml
@@ -1,0 +1,3 @@
+com.pelagicore.ivi.tuner.Tuner{
+   extra:
+    extraA: true

--- a/tests/in/invalid_tuner_annotations.yaml
+++ b/tests/in/invalid_tuner_annotations.yaml
@@ -1,0 +1,3 @@
+com.pelagicore.ivi.tuner.Tunerrrrrrrr:
+   extra:
+    extraA: true

--- a/tests/in/tuner_annotations.yaml
+++ b/tests/in/tuner_annotations.yaml
@@ -1,0 +1,3 @@
+com.pelagicore.ivi.tuner.Tuner:
+   extra:
+    extraA: true

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -69,6 +69,16 @@ def test_merge_annotation():
     assert interface.attribute('extra', 'extraA') is True
 
 @patch('sys.stderr', new_callable=StringIO)
+def test_merge_empty_annotation(mock_stderr):
+    system = loadTuner()
+    interface = system.lookup('com.pelagicore.ivi.tuner.Tuner')
+    assert interface
+    FileSystem.merge_annotations(system, inputPath / 'empty_tuner_annotations.yaml')
+
+    assert interface.attribute('extra', 'extraA') is None
+    assert not mock_stderr.getvalue().__contains__("Error parsing annotation")
+
+@patch('sys.stderr', new_callable=StringIO)
 def test_merge_broken_annotation(mock_stderr):
     system = loadTuner()
     interface = system.lookup('com.pelagicore.ivi.tuner.Tuner')


### PR DESCRIPTION
The System.lookup() function is now throwing an exception when the name
couldn't be found, instead of just returning None.

This exception is catched in the FileSystem object and printed on
stderr.

In strict mode, any annotation error results in exiting the generator.

Fixes: #90 #64