### PR TITLE
Fix parse issue due to missing space

### DIFF
--- a/qface/idl/listener.py
+++ b/qface/idl/listener.py
@@ -1,5 +1,6 @@
 # Copyright (c) Pelagicore AB 2016
 import logging
+import re
 
 import antlr4.atn.ATNDeserializer
 if (antlr4.atn.ATNDeserializer.SERIALIZED_VERSION == 3):
@@ -115,6 +116,7 @@ class DomainListener(QFaceListener):
             symbol.comment = comment
         if ctx.tagSymbol():
             lines = [tag.line.text[1:] for tag in ctx.tagSymbol()]
+            lines = [re.sub(r':\s*', ': ', line) for line in lines]
             try:
                 data = yaml.load('\n'.join(lines), Loader=Loader)
                 symbol._tags = data

--- a/tests/in/com.pelagicore.ivi.tuner.qface
+++ b/tests/in/com.pelagicore.ivi.tuner.qface
@@ -9,7 +9,7 @@ interface BaseTuner {
 /** Service Tuner */
 @service: true
 @interface: true
-@config: {private: true, b: B, c: C}
+@config: {private: true, b: B, c: C, d:D}
 @data: [1,2,3]
 interface Tuner extends BaseTuner {
     /** property currentStation */

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -114,7 +114,9 @@ def test_error_template_syntax_error(mock_stderr):
     generator.write(dst_template, 'syntaxError.txt', ctx)
     path = generator.apply(dst_template, ctx)
     assert Path(path).exists() == False
-    assert mock_stderr.getvalue() == "tests/templates/syntaxError.txt:1: error: Encountered unknown tag 'fooo'.\n"
+    expected_error = "tests/templates/syntaxError.txt:1: error: Encountered unknown tag 'fooo'.\n"
+    actual_output = mock_stderr.getvalue().replace("\\", "/")  # Normalize backslashes
+    assert expected_error in actual_output, f"Expected error not found. Expected: {expected_error}, Actual: {actual_output}"
 
 @patch('sys.stderr', new_callable=StringIO)
 def test_error_template_undefined_variable(mock_stderr):
@@ -127,7 +129,9 @@ def test_error_template_undefined_variable(mock_stderr):
     generator.write(dst_template, 'undefinedVariable.txt', ctx)
     path = generator.apply(dst_template, ctx)
     assert Path(path).exists() == False
-    assert mock_stderr.getvalue() == "tests/templates/undefinedVariable.txt:1: error: 'this_is_not_defined' is undefined\n"
+    expected_error = "tests/templates/undefinedVariable.txt:1: error: 'this_is_not_defined' is undefined\n"
+    actual_output = mock_stderr.getvalue().replace("\\", "/")  # Normalize backslashes
+    assert expected_error in actual_output, f"Expected error not found. Expected: {expected_error}, Actual: {actual_output}"
 
 @patch('sys.stderr', new_callable=StringIO)
 def test_error_template_doesnt_exist(mock_stderr):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -60,6 +60,7 @@ def test_flag():
     assert interface.attribute('config', 'a') == 'a'  # use value from yaml
     assert interface.attribute('config', 'b') == 'b'  # use value from yaml
     assert interface.attribute('config', 'c') == 'C'  # use value from IDL
+    assert interface.attribute('config', 'd') == 'D'  # use value from IDL, No Space after :
     assert interface.tags['data'] == [1, 2, 3]  # array annotatiom
 
 def test_merge_annotation():
@@ -89,7 +90,9 @@ def test_merge_broken_annotation(mock_stderr):
     FileSystem.merge_annotations(system, inputPath / 'broken_tuner_annotations.yaml')
 
     assert interface.attribute('extra', 'extraA') is None
-    assert mock_stderr.getvalue().__contains__("tests/in/broken_tuner_annotations.yaml:2: error: mapping values are not allowed")
+    expected_error = "tests/in/broken_tuner_annotations.yaml:2: error: mapping values are not allowed"
+    actual_output = mock_stderr.getvalue().replace("\\", "/")  # Normalize backslashes
+    assert expected_error in actual_output, f"Expected error not found. Expected: {expected_error}, Actual: {actual_output}"
 
 @patch('sys.stderr', new_callable=StringIO)
 def test_merge_invalid_annotation(mock_stderr):
@@ -99,4 +102,6 @@ def test_merge_invalid_annotation(mock_stderr):
     FileSystem.merge_annotations(system, inputPath / 'invalid_tuner_annotations.yaml')
 
     assert interface.attribute('extra', 'extraA') is None
-    assert mock_stderr.getvalue() == "Error parsing annotation tests/in/invalid_tuner_annotations.yaml: not able to lookup symbol: Tunerrrrrrrr\n"
+    expected_error = "Error parsing annotation tests/in/invalid_tuner_annotations.yaml: not able to lookup symbol: Tunerrrrrrrr\n"
+    actual_output = mock_stderr.getvalue().replace("\\", "/")  # Normalize backslashes
+    assert expected_error in actual_output, f"Expected error not found. Expected: {expected_error}, Actual: {actual_output}"


### PR DESCRIPTION
QTBUG-129592 : Parsing error due to missing space between key and value in annotations in QFace file.