### PR TITLE
CI: Improve coverage and enable the flow again

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,48 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Build and Test
+
+on:
+  workflow_call:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        dependencies: [minimal, latest]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest setuptools wheel twine
+        if [ ${{ matrix.dependencies }} == "latest" ]; then
+          pip install -r requirements.txt;
+        else
+          pip install -r requirements_minimal.txt;
+        fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        if [ ${{ matrix.dependencies }} == "latest" ]; then
+          python -m pytest -v -s -l -W error::DeprecationWarning
+        else
+          python -m pytest -v -s -l
+        fi

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,11 +11,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
         dependencies: [minimal, latest]
 
     steps:
@@ -24,6 +24,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/on_change.yml
+++ b/.github/workflows/on_change.yml
@@ -1,12 +1,23 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Weekly Check
+name: On Change
 
 on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
   schedule:
     - cron: '0 1 * * 1'
 
 jobs:
   build:
     uses: ./.github/workflows/build-test.yml
+
+  upload:
+    uses: ./.github/workflows/python-package.yml
+    needs: [ build ]
+    if: ${{ github.event_name == 'push' }}
+    with:
+      use_testpypi: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,42 +11,7 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
-        dependencies: [minimal, latest]
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest setuptools wheel twine
-        if [ ${{ matrix.dependencies }} == "latest" ]; then
-          pip install -r requirements.txt;
-        else
-          pip install -r requirements_minimal.txt;
-        fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        if [ ${{ matrix.dependencies }} == "latest" ]; then
-          python -m pytest -v -s -l -W error::DeprecationWarning
-        else
-          python -m pytest -v -s -l
-        fi
+    uses: ./.github/workflows/build-test.yml
 
   upload:
     needs: [ build ]

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   upload:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.7

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,18 +4,14 @@
 name: Python package
 
 on:
-  push:
-    branches: [ develop ]
-  pull_request:
-    branches: [ develop ]
+  workflow_call:
+    inputs:
+      use_testpypi:
+        required: true
+        type: boolean
 
 jobs:
-  build:
-    uses: ./.github/workflows/build-test.yml
-
   upload:
-    needs: [ build ]
-    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
@@ -29,6 +25,7 @@ jobs:
         python -m pip install setuptools wheel twine
         pip install -r requirements_minimal.txt;
     - name: Upload to TestPyPI
+      if: ${{ inputs.use_testpypi }}
       run: |
         python3 setup.py sdist bdist_wheel --build-number $GITHUB_RUN_NUMBER
         python3 -m twine upload --skip-existing dist/*
@@ -36,3 +33,11 @@ jobs:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.TESTPYPI_API_TOKEN }}
         TWINE_REPOSITORY: testpypi
+    - name: Upload to PyPI
+      if: ${{ !inputs.use_testpypi }}
+      run: |
+        python3 setup.py sdist bdist_wheel --build-number $GITHUB_RUN_NUMBER
+        python3 -m twine upload --skip-existing dist/*
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,23 +15,7 @@ jobs:
     uses: ./.github/workflows/build-test.yml
 
   upload:
+    uses: ./.github/workflows/python-package.yml
     needs: [ build ]
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.7
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install setuptools wheel twine
-        pip install -r requirements_minimal.txt;
-    - name: Upload to PyPI
-      run: |
-        python3 setup.py sdist bdist_wheel --build-number $GITHUB_RUN_NUMBER
-        python3 -m twine upload --skip-existing dist/*
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+    with:
+      use_testpypi: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,42 +12,7 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
-        dependencies: [minimal, latest]
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest setuptools wheel twine
-        if [ ${{ matrix.dependencies }} == "latest" ]; then
-          pip install -r requirements.txt;
-        else
-          pip install -r requirements_minimal.txt;
-        fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        if [ ${{ matrix.dependencies }} == "latest" ]; then
-          python -m pytest -v -s -l -W error::DeprecationWarning
-        else
-          python -m pytest -v -s -l
-        fi
+    uses: ./.github/workflows/build-test.yml
 
   upload:
     needs: [ build ]

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -42,11 +42,3 @@ jobs:
         else
           python -m pytest -v -s -l
         fi
-  keepalive-job:
-    name: Keepalive Workflow
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: gautamkrishnar/keepalive-workflow@v2

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -7,38 +7,6 @@ on:
   schedule:
     - cron: '0 1 * * 1'
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
 jobs:
   build:
-
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
-        dependencies: [minimal, latest]
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pytest setuptools wheel
-        if [ ${{ matrix.dependencies }} == "latest" ]; then
-          pip install -r requirements.txt;
-        else
-          pip install -r requirements_minimal.txt;
-        fi
-    - name: Test with pytest
-      run: |
-        if [ ${{ matrix.dependencies }} == "latest" ]; then
-          python -m pytest -v -s -l -W error::DeprecationWarning
-        else
-          python -m pytest -v -s -l
-        fi
+    uses: ./.github/workflows/build-test.yml

--- a/requirements_minimal.txt
+++ b/requirements_minimal.txt
@@ -1,4 +1,4 @@
-antlr4-python3-runtime==4.7.1
+antlr4-python3-runtime==4.9
 argh==0.26.2
 click==6.7
 coloredlogs==10.0

--- a/requirements_minimal.txt
+++ b/requirements_minimal.txt
@@ -7,5 +7,6 @@ MarkupSafe==1.1
 PyYAML==5.1
 six==1.11.0
 watchdog==1.0
-pytest==6.2.5
+pytest==6.2.5; python_version < '3.14'
+pytest==8; python_version >= '3.14'
 pytest-cov==2.8.1


### PR DESCRIPTION
Seems the keep alive workflow got blocked by github, remove this again to enable the CI again.

Reworked the used actions to make them more maintable.

Added support for Python 3.13 and 3.14